### PR TITLE
(UI-011) Modal 컴포넌트 개발

### DIFF
--- a/packages/ui/components/Modal.tsx
+++ b/packages/ui/components/Modal.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import classnames from "classnames";
+import { Text, Flex } from "..";
+
+import "../scss/modal.scss";
+
+type ModalProps = {
+	open: boolean;
+	modalTitle?: string;
+	onClose: () => void;
+	children: React.ReactNode;
+};
+
+export const Modal: React.FC<ModalProps> = ({
+	open,
+	modalTitle,
+	onClose,
+	children,
+}) => {
+	return (
+		<div
+			className={classnames("modal-wrapper", {
+				visible: open,
+				hidden: !open,
+			})}
+			onClick={onClose}
+		>
+			<div
+				className={classnames("modal-content")}
+				onClick={(e) => e.stopPropagation()}
+			>
+				{modalTitle && <Text variant="h2">{modalTitle}</Text>}
+				{children}
+			</div>
+		</div>
+	);
+};

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -6,3 +6,4 @@ export * from "./components/Flex";
 export * from "./components/TextInput";
 export * from "./components/TextArea";
 export * from "./components/CancleButton";
+export * from "./components/Modal";

--- a/packages/ui/scss/modal.scss
+++ b/packages/ui/scss/modal.scss
@@ -1,0 +1,32 @@
+.modal-wrapper {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	background-color: rgba(0, 0, 0, 0.5);
+	z-index: 10;
+	opacity: 0;
+	transition: opacity 0.3s ease-in-out;
+
+	&.visible {
+		opacity: 1;
+	}
+
+	&.hidden {
+		pointer-events: none;
+	}
+}
+
+.modal-content {
+	max-width: 60%;
+	max-height: 60%;
+	overflow: auto;
+	background-color: white;
+	border-radius: 4px;
+	padding: 10px;
+	box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+}


### PR DESCRIPTION
## 이 PR은 무엇을 하는 PR인가요?

프로젝트 전체에서 사용될  Modal 컴포넌트를 개발합니다. 

## 변경된 내용은 어떤가요?

Modal 컴포넌트는 현재 최소한의 기능을 포함합니다. 
입력받은 props는 
	open: boolean;
	modalTitle?: string;
	onClose: () => void;
	children: React.ReactNode;
가 있습니다. 

현재 modal 컴포넌트는 page에서 직접 사용하는 것이 아닌 각각의 서비스에서 커스텀의 바탕이 되는 용도로 사용하는 것을 상정하여 개발 되었습니다. 

## 특이사항

특이사항으로는 좀 더 개선할 여지가 있습니다. 
1. 여러개의 modal이 동시에 동작하게 되는 경우를 대처하지 않음,
2. modal 내부의 스크롤이 가능할 때, children에서만 하는 것이 바람직할것으로 보임,
3. modal이 등장하면서 opacity 조절을 통해서 자연스러운 등장을 하려 했으나 가볍게 시도할때 실패하여, 현재 최소 기능만으로 배포합니다. 
